### PR TITLE
Remove 'port' field from CoreConfig struct

### DIFF
--- a/services/appview/src/config.rs
+++ b/services/appview/src/config.rs
@@ -22,7 +22,6 @@ pub struct CoreConfig {
     pub hostname: Option<String>,
     pub frontend: String,
     pub did: Option<String>,
-    pub port: Option<u16>,
     pub privacy_policy_url: Option<String>,
     pub terms_of_service_url: Option<String>,
     pub contact_email_address: Option<String>,


### PR DESCRIPTION
Removed the 'port' field from CoreConfig struct.